### PR TITLE
general: restrict ci push action to main branch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,11 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Modifies the ci actions to only run the push job for the main branch.  It should run for any pull request branch.  This prevents CI from running twice on pull requests.