### PR TITLE
lightning: removes `signFundingTx` method

### DIFF
--- a/docs/routines/createFundingTx.md
+++ b/docs/routines/createFundingTx.md
@@ -21,3 +21,7 @@ Constructs a partial transaction with one or more inputs sufficient to cover the
 -   Once this transaction is created, we can use the outpoint (txid + output index). We will hold off on broadcasting the funding transaction until we have a valid commitment signature from our peer.
 -   This transaction should only use segwit BIP141 (SegWit) inputs.
 -   If the funding transaction fails to confirm within 2016 blocks, the fundee (accepting node) will forget the channel. As such it is recommended to include a change output that is eligible for fee bumping the funding transaction via CPFP
+
+This function calls the bitcoin wallet to obtain inputs that are sufficient to cover the `fundingAmount` and ensure the funding transaction is confirmed immediately.
+
+The result of this function is an immutable, ready-to-broadcast funding transaction.

--- a/docs/routines/signFundingTx.md
+++ b/docs/routines/signFundingTx.md
@@ -1,7 +1,0 @@
-## Subroutine `signFundingTx`
-
-Inputs:
-
--   `fundingTx`: `TxBuilder`
-
-Used by the funder. This method accepts a completed funding transaction as an argument. The funder's on-chain wallet will known how to sign this transaction based on the used UTXOs and will perform the appropriate signing and input configurations. The wallet should return an immutable and broadcastable transaction.

--- a/docs/routines/walletFundTx.md
+++ b/docs/routines/walletFundTx.md
@@ -9,3 +9,5 @@ Wallet function that will spend one or more UTXOs to pay for the outputs in the 
 This transaction should only use segwit BIP141 (SegWit) inputs to ensure the transaction is not malleable.
 
 Additionally the transaction should enable opt-in full replace-by-fee by setting at least one input's nSequence value to 0xfffffffe or less. This is because if the funding transaction fails to confirm within 2016 blocks, the fundee (accepting node) will forget the channel.
+
+The result of this function is a completed transaction that is ready for broadcast to the network.

--- a/docs/transitions/transition_0021.md
+++ b/docs/transitions/transition_0021.md
@@ -17,7 +17,6 @@ Once the transaction is broadcast the funder must remember the channel. We don't
 #### Actions
 
 1. Attach `funding_signed` information to `channel` - [`attachFundingSigned`](../routines/attachFundingSigned.md)
-1. Sign the funding transaction - [`signFundingTx` subroutine](../routines/signTx.md)
 1. Broadcast funding transaction - [`broadcastTx` subroutine](../routines/broadcastTx.md)
 1. Transition to `AwaitingFundingDepth` channel state
 

--- a/packages/lightning/__tests__/_test-utils.ts
+++ b/packages/lightning/__tests__/_test-utils.ts
@@ -103,7 +103,6 @@ export function createFakeChannelWallet(): Sinon.SinonStubbedInstance<IChannelWa
         createBasePointSecrets: Sinon.stub(),
         createPerCommitmentSeed: Sinon.stub(),
         fundTx: Sinon.stub(),
-        signTx: Sinon.stub(),
         signFundingTx: Sinon.stub(),
         broadcastTx: Sinon.stub(),
         getBlockHeight: Sinon.stub(),

--- a/packages/lightning/__tests__/channels/Helpers.spec.ts
+++ b/packages/lightning/__tests__/channels/Helpers.spec.ts
@@ -1455,7 +1455,7 @@ describe(Helpers.name, () => {
 
                 // enable rbf
                 tx.locktime = LockTime.zero();
-                return tx;
+                return tx.toTx();
             });
             const channel = createFakeChannel().attachAcceptChannel(createFakeAcceptChannel());
             const preferences = new ChannelPreferences();
@@ -1700,25 +1700,6 @@ describe(Helpers.name, () => {
 
             // assert
             expect(result).to.equal(false);
-        });
-    });
-
-    describe(Helpers.prototype.signFundingTx.name, () => {
-        it("calls the wallet", async () => {
-            // arrange
-            const channel = createFakeChannel()
-                .attachAcceptChannel(createFakeAcceptChannel())
-                .attachFundingTx(createFakeFundingTx());
-            const wallet = createFakeChannelWallet();
-            const fakeTx = new Tx();
-            wallet.signFundingTx.resolves(fakeTx);
-            const helpers = new Helpers(wallet, undefined, undefined);
-
-            // act
-            const result = await helpers.signFundingTx(channel);
-
-            // assert
-            expect(result).to.equal(fakeTx);
         });
     });
 

--- a/packages/lightning/__tests__/channels/states/AwaitingFundingSignedState.spec.ts
+++ b/packages/lightning/__tests__/channels/states/AwaitingFundingSignedState.spec.ts
@@ -1,4 +1,3 @@
-import { Tx } from "@node-lightning/bitcoin";
 import { ILogger } from "@node-lightning/logger";
 import { expect } from "chai";
 import { Channel } from "../../../lib/channels/Channel";
@@ -16,6 +15,7 @@ import {
     createFakeChannel,
     createFakeAcceptChannel,
     createFakeFundingSignedMessage,
+    createFakeFundingTx,
 } from "../../_test-utils";
 
 describe(AwaitingFundingSignedState.name, () => {
@@ -52,13 +52,11 @@ describe(AwaitingFundingSignedState.name, () => {
         });
         describe("valid message", () => {
             let msg: FundingSignedMessage;
-            let fundingTx: Tx;
 
             beforeEach(() => {
                 msg = createFakeFundingSignedMessage();
-                fundingTx = new Tx();
+                channel.attachFundingTx(createFakeFundingTx());
                 logic.validateFundingSignedMessage.resolves(Result.ok(true));
-                logic.signFundingTx.resolves(fundingTx);
             });
 
             it("attaches signature to channel", async () => {

--- a/packages/lightning/lib/channels/Helpers.ts
+++ b/packages/lightning/lib/channels/Helpers.ts
@@ -617,7 +617,7 @@ export class Helpers implements IChannelLogic {
     }
 
     /**
-     * Constructs a partial transaction with one or more inputs
+     * Constructs a completed transaction with one or more inputs
      * sufficient to cover the `funding_satoshis` value. Contains one or
      * more outputs, one of which must be the funding output. The funding
      * transaction is defined BOLT 3. This funding output must be a
@@ -630,6 +630,10 @@ export class Helpers implements IChannelLogic {
      * The pubkeys are the lexicographical ordering of the
      * `funding_pubkey` values. Lexicographical ordering improves privacy
      * by not leaking which of the nodes is the funding node.
+     *
+     * This function calls the bitcoin wallet to obtain inputs that are
+     * sufficient to cover the `fundingAmount` and ensure the funding
+     * transaction is confirmed immediately.
      * @param channel
      * @returns
      */
@@ -642,8 +646,7 @@ export class Helpers implements IChannelLogic {
                 channel.theirSide.fundingPubKey.toBuffer(),
             ),
         );
-        await this.wallet.fundTx(tx);
-        return tx.toTx();
+        return await this.wallet.fundTx(tx);
     }
 
     /**
@@ -835,18 +838,6 @@ export class Helpers implements IChannelLogic {
         if (!result) {
             return OpeningError.toResult(OpeningErrorType.InvalidCommitmentSig);
         }
-    }
-
-    /**
-     * Used by the funder. This method accepts a completed funding
-     * transaction as an argument. The funder's on-chain wallet will
-     * known how to sign this transaction based on the used UTXOs and
-     * will perform the appropriate signing and input configurations.
-     * The wallet should return an immutable and broadcastable transaction.
-     * @param channel
-     */
-    public async signFundingTx(channel: Channel): Promise<Tx> {
-        return await this.wallet.signFundingTx(channel.fundingTx);
     }
 
     /**

--- a/packages/lightning/lib/channels/Helpers.ts
+++ b/packages/lightning/lib/channels/Helpers.ts
@@ -634,6 +634,9 @@ export class Helpers implements IChannelLogic {
      * This function calls the bitcoin wallet to obtain inputs that are
      * sufficient to cover the `fundingAmount` and ensure the funding
      * transaction is confirmed immediately.
+     *
+     * The result of this function is an immutable, ready-to-broadcast
+     * funding transaction.
      * @param channel
      * @returns
      */

--- a/packages/lightning/lib/channels/IChannelLogic.ts
+++ b/packages/lightning/lib/channels/IChannelLogic.ts
@@ -38,7 +38,6 @@ export interface IChannelLogic {
     createTempChannelId(): Buffer;
     sendMessage(peerId: string, msg: IWireMessage);
     signCommitmentTx(channel: Channel, ctx: TxBuilder): Promise<Buffer>;
-    signFundingTx(channel: Channel): Promise<Tx>;
     validateAcceptChannel(
         channel: Channel,
         msg: AcceptChannelMessage,

--- a/packages/lightning/lib/channels/IChannelWallet.ts
+++ b/packages/lightning/lib/channels/IChannelWallet.ts
@@ -8,8 +8,7 @@ export interface IChannelWallet {
     createFundingKey(): Promise<PrivateKey>;
     createBasePointSecrets(): Promise<CreateBasePointsResult>;
     createPerCommitmentSeed(): Promise<Buffer>;
-    fundTx(builder: TxBuilder): Promise<TxBuilder>;
-    signTx(builder: TxBuilder): Promise<TxBuilder>;
+    fundTx(builder: TxBuilder): Promise<Tx>;
     signFundingTx(tx: Tx): Promise<Tx>;
     broadcastTx(tx: Tx): Promise<void>;
     getBlockHeight(): Promise<number>;

--- a/packages/lightning/lib/channels/states/opening/AwaitingFundingSignedState.ts
+++ b/packages/lightning/lib/channels/states/opening/AwaitingFundingSignedState.ts
@@ -19,9 +19,6 @@ export class AwaitingFundingSignedState extends StateMachine {
         // Attach funding_signed information to channel
         channel.attachFundingSigned(msg);
 
-        // Sign the funding transaction
-        channel.fundingTx = await this.logic.signFundingTx(channel);
-
         // Broadcast funding transaction
         await this.logic.broadcastTx(channel.fundingTx);
 


### PR DESCRIPTION
Closes #277 

Modifies the meaning of `fundTx` to result in a broadcastable transaction.  Updates the documentation accordingly.  Modifies `AwaitingFundingSignedState` accordingly.