### PR TITLE
lightning: splits channel.opening into init and funding

### DIFF
--- a/packages/lightning/__tests__/channels/TransitionFactory.spec.ts
+++ b/packages/lightning/__tests__/channels/TransitionFactory.spec.ts
@@ -122,7 +122,7 @@ describe(TransitionFactory.name, () => {
                 const result = await sut.createOnAcceptChannelMessageTransition()(channel, event);
 
                 // assert
-                expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingSigned);
+                expect(result).to.equal(ChannelStateId.Channel_Initializing_AwaitingFundingSigned);
             });
         });
     });
@@ -197,7 +197,7 @@ describe(TransitionFactory.name, () => {
                 const result = await sut.createOnFundingSignedMessageTransition()(channel, event);
 
                 // assert
-                expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingDepth);
+                expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingFundingDepth);
             });
         });
     });
@@ -229,7 +229,7 @@ describe(TransitionFactory.name, () => {
 
             // assert
             expect(channel.fundingConfirmedHeight).to.equal(undefined);
-            expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingDepth);
+            expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingFundingDepth);
         });
 
         it("confirmed => attaches height, stays", async () => {
@@ -245,7 +245,7 @@ describe(TransitionFactory.name, () => {
             // assert
             expect(channel.fundingConfirmedHeight).to.equal(500_000);
             expect(channel.readyHeight).to.equal(500_005);
-            expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingDepth);
+            expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingFundingDepth);
         });
 
         it("confirmed + height => stays", async () => {
@@ -261,7 +261,7 @@ describe(TransitionFactory.name, () => {
             // assert
             expect(channel.fundingConfirmedHeight).to.equal(500_000);
             expect(channel.readyHeight).to.equal(500_005);
-            expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingDepth);
+            expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingFundingDepth);
         });
 
         it("meets depth, no channel_ready => sends channel_ready + transitions to awaiting_channel_ready", async () => {
@@ -275,7 +275,7 @@ describe(TransitionFactory.name, () => {
             const result = await sut.createOnBlockConnected()(channel, event);
 
             // assert
-            expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingChannelReady);
+            expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingChannelReady);
             expect(logic.sendMessage.called).to.equal(true);
         });
 
@@ -323,7 +323,7 @@ describe(TransitionFactory.name, () => {
 
                 // act
                 const result = await sut.createOnChannelReadyTransition(
-                    ChannelStateId.Channel_Opening_AwaitingFundingDepth,
+                    ChannelStateId.Channel_Funding_AwaitingFundingDepth,
                 )(channel, event);
 
                 // assert
@@ -339,9 +339,9 @@ describe(TransitionFactory.name, () => {
 
                 // act
                 const result = await sut.createOnChannelReadyTransition(
-                    ChannelStateId.Channel_Opening_AwaitingFundingDepth,
+                    ChannelStateId.Channel_Funding_AwaitingFundingDepth,
                 )(channel, event);
-                expect(result).to.equal(ChannelStateId.Channel_Opening_AwaitingFundingDepth);
+                expect(result).to.equal(ChannelStateId.Channel_Funding_AwaitingFundingDepth);
                 expect(channel.theirSide.commitmentNumber.value).to.equal(0n);
                 expect(channel.theirSide.commitmentPoint.toHex()).to.equal(
                     "0288a618cb6027c3218a37cbe9e882379f17d87d03f6e99d0b60292478d2aded06",

--- a/packages/lightning/lib/channels/ChannelManager.ts
+++ b/packages/lightning/lib/channels/ChannelManager.ts
@@ -152,7 +152,7 @@ export class ChannelManager {
         await this.transitionState(
             channel,
             undefined,
-            ChannelStateId.Channel_Opening_AwaitingAcceptChannel,
+            ChannelStateId.Channel_Initializing_AwaitingAcceptChannel,
         );
 
         // Add to channels

--- a/packages/lightning/lib/channels/StateMachineFactory.ts
+++ b/packages/lightning/lib/channels/StateMachineFactory.ts
@@ -4,10 +4,10 @@ import { StateMachine } from "./StateMachine";
 import { TransitionFactory } from "./TransitionFactory";
 
 export enum ChannelStateId {
-    Channel_Opening_AwaitingAcceptChannel = "channel.opening.awaiting_accept_channel",
-    Channel_Opening_AwaitingFundingSigned = "channel.opening.awaiting_funding_signed",
-    Channel_Opening_AwaitingFundingDepth = "channel.opening.awaiting_funding_depth",
-    Channel_Opening_AwaitingChannelReady = "channel.opening.awaiting_channel_ready",
+    Channel_Initializing_AwaitingAcceptChannel = "channel.initializing.awaiting_accept_channel",
+    Channel_Initializing_AwaitingFundingSigned = "channel.initializing.awaiting_funding_signed",
+    Channel_Funding_AwaitingFundingDepth = "channel.funding.awaiting_funding_depth",
+    Channel_Funding_AwaitingChannelReady = "channel.funding.awaiting_channel_ready",
     Channel_Failing = "channel.failing",
     Channel_Normal = "channel.normal",
     Channel_Abandoned = "channel.abandoned",
@@ -19,7 +19,7 @@ export class StateMachineFactory {
     public construct(): StateMachine {
         return new StateMachine(this.logger, "channel")
             .addSubState(
-                new StateMachine(this.logger, "opening")
+                new StateMachine(this.logger, "initializing")
                     .addSubState(
                         new StateMachine(this.logger, "awaiting_accept_channel").addTransition(
                             ChannelEventType.AcceptChannelMessage,
@@ -31,7 +31,10 @@ export class StateMachineFactory {
                             ChannelEventType.FundingSignedMessage,
                             this.transitions.createOnFundingSignedMessageTransition(),
                         ),
-                    )
+                    ),
+            )
+            .addSubState(
+                new StateMachine(this.logger, "funding")
                     .addSubState(
                         new StateMachine(this.logger, "awaiting_funding_depth")
                             .addTransition(
@@ -41,7 +44,7 @@ export class StateMachineFactory {
                             .addTransition(
                                 ChannelEventType.ChannelReadyMessage,
                                 this.transitions.createOnChannelReadyTransition(
-                                    ChannelStateId.Channel_Opening_AwaitingFundingDepth,
+                                    ChannelStateId.Channel_Funding_AwaitingFundingDepth,
                                 ),
                             ),
                     )

--- a/packages/lightning/lib/channels/TransitionFactory.ts
+++ b/packages/lightning/lib/channels/TransitionFactory.ts
@@ -57,7 +57,7 @@ export class TransitionFactory {
             await this.logic.sendMessage(channel.peerId, fundingCreatedMessage);
 
             // return new state
-            return ChannelStateId.Channel_Opening_AwaitingFundingSigned;
+            return ChannelStateId.Channel_Initializing_AwaitingFundingSigned;
         };
     }
 
@@ -80,7 +80,7 @@ export class TransitionFactory {
             await this.logic.broadcastTx(channel.fundingTx);
 
             // Transition to AwaitingFundingDepth state
-            return ChannelStateId.Channel_Opening_AwaitingFundingDepth;
+            return ChannelStateId.Channel_Funding_AwaitingFundingDepth;
         };
     }
 
@@ -116,11 +116,11 @@ export class TransitionFactory {
                 if (containsOutPoint(block, channel.fundingOutPoint)) {
                     const confirmedHeight = Number(block.bip34Height);
                     channel.markConfirmed(confirmedHeight);
-                    return ChannelStateId.Channel_Opening_AwaitingFundingDepth;
+                    return ChannelStateId.Channel_Funding_AwaitingFundingDepth;
                 }
 
                 // Otherwise we keep waiting
-                return ChannelStateId.Channel_Opening_AwaitingFundingDepth;
+                return ChannelStateId.Channel_Funding_AwaitingFundingDepth;
             }
 
             // When block height reaches ready height...
@@ -143,13 +143,13 @@ export class TransitionFactory {
                 // Otherwise we transition to waiting for the `channel_ready`
                 // message
                 else {
-                    return ChannelStateId.Channel_Opening_AwaitingChannelReady;
+                    return ChannelStateId.Channel_Funding_AwaitingChannelReady;
                 }
             }
 
             // Otherwise we're between the confirmed height and the ready height
             // so we stay here and wait for blocks to be solved.
-            return ChannelStateId.Channel_Opening_AwaitingFundingDepth;
+            return ChannelStateId.Channel_Funding_AwaitingFundingDepth;
         };
     }
 


### PR DESCRIPTION
This breaks the single opening state into two substates initializing which closes #297 and funding which closes #298. These new states will have transition logic for disconnects, shutdown, and error messages.