### PR TITLE
bitcoin: fix value floating point precision issue

### DIFF
--- a/packages/bitcoin/__tests__/Value.spec.ts
+++ b/packages/bitcoin/__tests__/Value.spec.ts
@@ -7,6 +7,7 @@ describe("Value", () => {
         expect(Value.fromBitcoin(0.12345678).bitcoin).to.equal(0.12345678);
         expect(Value.fromBitcoin(1).bitcoin).to.equal(1);
         expect(Value.fromBitcoin(1.23).bitcoin).to.equal(1.23);
+        expect(Value.fromBitcoin(20000000.00000008).bitcoin).to.equal(20000000.00000008);
     });
 
     it("#fromSats()", () => {

--- a/packages/bitcoin/lib/Value.ts
+++ b/packages/bitcoin/lib/Value.ts
@@ -11,7 +11,7 @@ export class Value implements ICloneable<Value> {
      * @param num
      */
     public static fromBitcoin(num: number): Value {
-        return Value.fromSats(Math.trunc(num * 1e8));
+        return Value.fromSats(Math.round(num * 1e8));
     }
 
     /**


### PR DESCRIPTION
Switches `Value.fromBitcoin` to use `Math.round` instead of `Math.trunc` since it can result in off by one sat issues
